### PR TITLE
chore: change pwa manifest name to tellbow

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -117,8 +117,8 @@ export default defineNuxtConfig({
     filename: sw ? "sw.ts" : undefined,
     registerType: "autoUpdate",
     manifest: {
-      name: "Nuxt Vite PWA",
-      short_name: "NuxtVitePWA",
+      name: "Tellbow",
+      short_name: "Tellbow",
       theme_color: "#ffffff",
       icons: [
         {


### PR DESCRIPTION
Fix the name of the PWA (e.g. when saving to IOS or Chrome).
Let me know if you want a name other than `Tellbow` :)

**Actual behavior on IOS**

![pwa-ios](https://github.com/user-attachments/assets/d65adfa0-84e7-4b0d-8c37-87b36637f4e0)

**Actual behavior on Chrome**

![chrome](https://github.com/user-attachments/assets/5a8d313d-d286-46db-bc76-7c0c4aa1851c)

**New behavior on Chrome**

![chrome-fix](https://github.com/user-attachments/assets/10ff5357-65c8-4a26-94b3-eac52c5b3787)
